### PR TITLE
Add missing README.md to fix installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md


### PR DESCRIPTION
Currently installation fails:

$ pip install ghost-client
Collecting ghost-client
  Downloading ghost_client-0.0.3.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/7k/pwdhb_mj2cv4zyr0kyrlzjx40000gq/T/pip-build-5Qwlzo/ghost-client/setup.py", line 8, in <module>
        long_description=open('README.md').read(),
    IOError: [Errno 2] No such file or directory: 'README.md'