### PR TITLE
api: fix classmethod usage

### DIFF
--- a/ghost_client/api.py
+++ b/ghost_client/api.py
@@ -165,7 +165,7 @@ class Ghost(object):
             ).fetchone()
 
             if row:
-                return Ghost(
+                return cls(
                     base_url, version=version,
                     client_id=client_id, client_secret=row[0]
                 )


### PR DESCRIPTION
The point of a classmethod is to use the class argument.